### PR TITLE
Add support for all formats supported by Fluentd's builtin parser

### DIFF
--- a/fluent-plugin-mqtt.gemspec
+++ b/fluent-plugin-mqtt.gemspec
@@ -17,13 +17,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "mqtt"
-  spec.add_development_dependency "fluentd"
   spec.add_runtime_dependency "mqtt"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "yajl-ruby"
   spec.add_runtime_dependency "test-unit"
-
+  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "rake"
 end

--- a/fluent-plugin-mqtt.gemspec
+++ b/fluent-plugin-mqtt.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "mqtt"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "yajl-ruby"
+  spec.add_runtime_dependency "test-unit"
 
 end

--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -53,7 +53,7 @@ module Fluent
       end
     end
 
-    def emit topic, message , time = Fluent::Engine.now
+    def emit topic, message, time = Fluent::Engine.now
       if message.class == Array
         message.each do |data|
           $log.debug "#{topic}: #{data}"

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -1,16 +1,16 @@
 require 'helper'
 
-class Fluent::MqttInput 
-  def emit topic, message , time = Fluent::Engine.now
-    if message.class == Array
-      message.each do |data|
-        $log.debug "#{topic}: #{data}"
-        Fluent::Engine.emit(topic, message["t"], data)
-      end
-    else
-      Fluent::Engine.emit(topic, message["t"], message)
-    end
-  end
+class Fluent::MqttInput
+  #def emit topic, message , time = Fluent::Engine.now
+    #if message.class == Array
+      #message.each do |data|
+        #$log.debug "#{topic}: #{data}"
+        #Fluent::Engine.emit(topic, message["t"], data)
+      #end
+    #else
+      #Fluent::Engine.emit(topic, message["t"], message)
+    #end
+  #end
 
 end
 
@@ -19,50 +19,221 @@ class MqttInputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
+ CONFIG = %[ bind 127.0.0.1
+             port 1883
+             format json ]
 
- CONFIG = %[
-  ]
-
-  def create_driver(conf = CONFIG) 
+  def create_driver(conf = CONFIG)
     Fluent::Test::InputTestDriver.new(Fluent::MqttInput).configure(conf)
   end
-  
-  def test_configure
+
+  def test_configure_1
     d = create_driver(
       %[ bind 127.0.0.1
-         port 1300 ] 
+         port 1883
+         format none]
     )
     assert_equal '127.0.0.1', d.instance.bind
-    assert_equal 1300, d.instance.port
+    assert_equal 1883, d.instance.port
+    assert_equal 'none', d.instance.format
+
+    d2 = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format csv
+         keys time,message
+         time_key time]
+    )
+    assert_equal 'csv', d2.instance.format
+    assert_equal 'time', d2.instance.time_key
   end
 
+  def test_configure_2
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format csv
+         keys time,message ]
+    )
+    assert_equal '127.0.0.1', d.instance.bind
+    assert_equal 1883, d.instance.port
+    assert_equal 'csv', d.instance.format
+  end
 
   def sub_client
-    connect = MQTT::Client.connect
+    connect = MQTT::Client.connect("localhost")
     connect.subscribe('#')
     return connect
   end
 
-
-  def test_client
-    d = create_driver
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i    
-    d.expect_emit "tag1", time, {"t" => time, "v" => {"a"=>1}}
-    d.expect_emit "tag2", time, {"t" => time, "v" => {"a"=>2}}
-    d.expect_emit "tag3", time, {"t" => time, "v" => {"a"=>31}}
-    d.expect_emit "tag3", time, {"t" => time, "v" => {"a"=>32}}
+  def test_format_json_without_time_key
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format json ]
+    )
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    data = [
+      {tag: "tag1", message: {"t" => time, "v" => {"a"=>1}}},
+      {tag: "tag2", message: {"t" => time, "v" => {"a"=>1}}},
+      {tag: "tag3", message: {"t" => time, "v" => {"a"=>32}}},
+    ]
 
     d.run do
-      d.expected_emits.each {|tag,time,record|
-        send_data tag, time, record
-      }
-      send_data "tag3", time , [{"t" => time, "v" => {"a"=>31}} , {"t" => time, "v" => {"a"=>32}}] 
-      sleep 0.5
+      data.each do |record|
+        send_data record[:tag], record[:message], d.instance.format
+        sleep 0.1
+      end
     end
 
+    emits = d.emits
+    assert_equal('tag1', emits[0][0])
+    assert_equal({"t" => time, "v" => {"a"=>1}}, emits[0][2])
+
+    assert_equal('tag2', emits[1][0])
+    assert_equal({"t" => time, "v" => {"a"=>1}}, emits[1][2])
+
+    assert_equal('tag3', emits[2][0])
+    assert_equal({"t" => time, "v" => {"a"=>32}}, emits[2][2])
   end
 
-  def send_data tag, time, record
-    sub_client.publish(tag, record.to_json)
+  def test_format_json_with_time_key
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format json
+         time_key t ]
+    )
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    data = [
+      {tag: "tag1", message: {"t" => time, "v" => {"a"=>1}}},
+      {tag: "tag2", message: {"t" => time, "v" => {"a"=>1}}},
+      {tag: "tag3", message: {"t" => time, "v" => {"a"=>31}}},
+      {tag: "tag3", message: {"t" => time, "v" => {"a"=>32}}},
+    ]
+
+    d.run do
+      data.each do |record|
+        send_data record[:tag], record[:message], d.instance.format
+      end
+    end
+
+    emits = d.emits
+    assert_equal('tag1', emits[0][0])
+    assert_equal(time, emits[0][1])
+    assert_equal({"v" => {"a"=>1}}, emits[0][2])
+  end
+
+  def test_format_none
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format none]
+    )
+
+    data = [
+      {tag: "tag1", message: 'hello world'},
+      {tag: "tag2", message: 'another world'},
+      {tag: "tag3", message: ''},
+    ]
+
+    d.run do
+      data.each do |record|
+        send_data record[:tag], record[:message], d.instance.format
+      end
+    end
+
+    emits = d.emits
+    time = Fluent::Engine.now
+    assert_equal('tag1', emits[0][0])
+    assert_equal({'message' => 'hello world'}, emits[0][2])
+    assert_equal('tag2', emits[1][0])
+    assert_equal({'message' => 'another world'}, emits[1][2])
+    assert_equal('tag3', emits[2][0])
+    assert_equal({'message' => ''}, emits[2][2])
+  end
+
+  def test_format_csv
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format csv
+         keys time,message]
+    )
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    data = [
+      {tag: "tag1", message: "#{time},hello world" },
+      {tag: "tag2", message: "#{time},hello to you to" },
+      {tag: "tag3", message: "#{time}," },
+    ]
+
+    d.run do
+      data.each do |record|
+        send_data record[:tag], record[:message], d.instance.format
+      end
+    end
+
+    emits = d.emits
+    #puts 'emits length', emits.length.to_s
+    assert_equal('tag1', emits[0][0])
+    assert_equal({'time' => time.to_s, 'message' => 'hello world'}, emits[0][2])
+
+    assert_equal('tag2', emits[1][0])
+    assert_equal({'time' => time.to_s, 'message' => 'hello to you to'}, emits[1][2])
+    assert_equal('tag3', emits[2][0])
+    assert_equal({'time' => time.to_s, 'message' => nil}, emits[2][2])
+  end
+
+  def test_format_csv_with_time_key
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format csv
+         keys time2,message
+         time_key time2
+         time_format %S]
+    )
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    data = [
+      {tag: "tag1", message: "#{time},abc" },
+      {tag: "tag2", message: "#{time},def" },
+      {tag: "tag3", message: "#{time},ghi" },
+      {tag: "tag3", message: "#{time}," },
+    ]
+
+    d.run do
+      data.each do |record|
+        send_data record[:tag], record[:message], d.instance.format
+      end
+    end
+
+    emits = d.emits
+    assert_equal('tag1', emits[0][0])
+    assert_equal({'message' => 'abc'}, emits[0][2])
+
+    assert_equal('tag2', emits[1][0])
+    assert_equal({'message' => 'def'}, emits[1][2])
+
+    assert_equal('tag3', emits[2][0])
+    assert_equal({'message' => 'ghi'}, emits[2][2])
+
+    assert_equal('tag3', emits[3][0])
+    assert_equal({'message' => nil}, emits[3][2])
+  end
+
+  def send_data tag, record, format
+    case format
+      when 'none'
+        sub_client.publish(tag, record)
+      when 'json'
+        sub_client.publish(tag, record.to_json)
+      when 'csv'
+        sub_client.publish(tag, record)
+      else
+        sub_client.publish(tag, record)
+    end
+    sleep 0.2
   end
 end


### PR DESCRIPTION
Currently the MQTT plugin only supports message in JSON format. I have modifed it to support all formats supported by Fluentd's built-in parser.
