### PR TITLE
Add output plugin and parser plugin support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'test-unit'
+
 # Specify your gem's dependencies in fluent-plugin-mqtt.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Or install it yourself as:
 
 ## Usage
 
-This client works as ONLY MQTT client.
-MQTT topic is set "#".
+fluent-plugin-mqtt provides Input and Output Plugins for MQTT.
+
+Input Plugin can be used via source directive in the configuration.
 
 ```
 
@@ -30,6 +31,33 @@ MQTT topic is set "#".
 </source>
 
 ```
+
+The default MQTT topic is "#". Configurable options are the following:
+
+- bind: IP address of MQTT broker
+- port: Port number of MQTT broker
+- topic: Topic name to be subscribed
+- username: User name for authentication
+- password: Password for authentication
+
+Output Plugin can be used via match directive.
+
+```
+
+<match topic.**>
+  type mqtt
+  bind 127.0.0.1
+  port 1883
+</match>
+
+```
+
+The options are basically the same as Input Plugin. The difference is related to the topic.
+
+- topic_rewrite_pattern: Regexp pattern to extract replacement words from received topic or tag name
+- topic_rewrite_replacement: Topic name used for the publish using extracted pattern
+
+The topic name or tag name, e.g. "topic", received from an event can not be published without modification because if MQTT input plugin is used as a source, the same message will become an input repeatedly. In order to support data conversion with this plugin using parser and formatter, flexible topic rewriting is supported.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The default MQTT topic is "#". Configurable options are the following:
 - topic: Topic name to be subscribed
 - username: User name for authentication
 - password: Password for authentication
+- format: Input parser can be chosen, e.g. json, xml
 
 Output Plugin can be used via match directive.
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,14 @@ Output Plugin can be used via match directive.
 
 ```
 
-The options are basically the same as Input Plugin. The difference is related to the topic.
+The options are basically the same as Input Plugin. The difference is the following.
 
+- time_key: An attribute name used for timestamp field. Default is 'timestamp'.
+- time_format: Output format of timestamp field. Default is ISO8601. You can specify your own format by using TimeParser.
 - topic_rewrite_pattern: Regexp pattern to extract replacement words from received topic or tag name
 - topic_rewrite_replacement: Topic name used for the publish using extracted pattern
 
-The topic name or tag name, e.g. "topic", received from an event can not be published without modification because if MQTT input plugin is used as a source, the same message will become an input repeatedly. In order to support data conversion with this plugin using parser and formatter, flexible topic rewriting is supported. Since topic is rewritten using #gsub method, 'pattern' and 'replacement' are the same as #gsub arguments.
+The topic name or tag name, e.g. "topic", received from an event can not be published without modification because if MQTT input plugin is used as a source, the same message will become an input repeatedly. In order to support data conversion with this plugin using parser plugin, simple topic rewriting is supported. Since topic is rewritten using #gsub method, 'pattern' and 'replacement' are the same as #gsub arguments.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,19 @@ The options are basically the same as Input Plugin. The difference is related to
 - topic_rewrite_pattern: Regexp pattern to extract replacement words from received topic or tag name
 - topic_rewrite_replacement: Topic name used for the publish using extracted pattern
 
-The topic name or tag name, e.g. "topic", received from an event can not be published without modification because if MQTT input plugin is used as a source, the same message will become an input repeatedly. In order to support data conversion with this plugin using parser and formatter, flexible topic rewriting is supported.
+The topic name or tag name, e.g. "topic", received from an event can not be published without modification because if MQTT input plugin is used as a source, the same message will become an input repeatedly. In order to support data conversion with this plugin using parser and formatter, flexible topic rewriting is supported. Since topic is rewritten using #gsub method, 'pattern' and 'replacement' are the same as #gsub arguments.
+
+```
+
+<match topic.**>
+  type mqtt
+  bind 127.0.0.1
+  port 1883
+  topic_rewrite_pattern '^([\w\/]+)$'
+  topic_rewrite_replacement '\1/rewritten'
+</match>
+
+```
 
 ## Contributing
 

--- a/fluent-plugin-mqtt.gemspec
+++ b/fluent-plugin-mqtt.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-mqtt"
-  spec.version       = "0.0.4"
-  spec.authors       = ["Yuuna Kurita"]
-  spec.email         = ["yuuna.m@gmail.com"]
+  spec.version       = "0.1.0"
+  spec.authors       = ["Yuuna Kurita", "Toyokazu Akiyama"]
+  spec.email         = ["yuuna.m@gmail.com", "toyokazu@gmail.com"]
   spec.summary       = %q{fluentd input plugin for mqtt server}
   spec.description   = %q{fluentd input plugin for mqtt server}
   spec.homepage      = "http://github.com/yuuna/fluent-plugin-mqtt"

--- a/fluent-plugin-mqtt.gemspec
+++ b/fluent-plugin-mqtt.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = "0.1.0"
   spec.authors       = ["Yuuna Kurita", "Toyokazu Akiyama"]
   spec.email         = ["yuuna.m@gmail.com", "toyokazu@gmail.com"]
-  spec.summary       = %q{fluentd input plugin for mqtt server}
-  spec.description   = %q{fluentd input plugin for mqtt server}
+  spec.summary       = %q{fluentd input/output plugin for mqtt server}
+  spec.description   = %q{fluentd input/output plugin for mqtt server}
   spec.homepage      = "http://github.com/yuuna/fluent-plugin-mqtt"
   spec.license       = "MIT"
 

--- a/fluent-plugin-mqtt.gemspec
+++ b/fluent-plugin-mqtt.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-mqtt"
-  spec.version       = "0.0.3"
+  spec.version       = "0.0.4"
   spec.authors       = ["Yuuna Kurita"]
   spec.email         = ["yuuna.m@gmail.com"]
   spec.summary       = %q{fluentd input plugin for mqtt server}
@@ -21,8 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mqtt"
   spec.add_development_dependency "fluentd"
-  spec.add_runtime_dependency "mqtt"
-  spec.add_runtime_dependency "fluentd"
-  spec.add_runtime_dependency "yajl-ruby"
 
 end

--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -11,6 +11,8 @@ module Fluent
     config_param :port, :integer, :default => 1883
     config_param :bind, :string, :default => '127.0.0.1'
     config_param :topic, :string, :default => '#'
+    config_param :username, :string, :default => nil
+    config_param :password, :string, :default => nil
 
     require 'mqtt'
 
@@ -19,11 +21,14 @@ module Fluent
       @bind ||= conf['bind']
       @topic ||= conf['topic']
       @port ||= conf['port']
+      @username ||= conf['username']
+      @password ||= conf['password']
     end
 
     def start
-      $log.debug "start mqtt #{@bind}"
-      @connect = MQTT::Client.connect({remote_host: @bind, remote_port: @port})
+      $log.debug "start mqtt host: #{@bind}, port: #{@port}, username: #{@username}, password: #{@password}"
+      @connect = MQTT::Client.connect(host: @bind, port: @port,
+                                      username: @username, password: @password)
       @connect.subscribe(@topic)
 
       @thread = Thread.new do

--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -39,7 +39,7 @@ module Fluent
 
       @thread = Thread.new do
         @connect.get do |topic,message|
-          #topic.gsub!("/","\.")
+          topic.gsub!("/","\.")
           $log.debug "#{topic}: #{message}"
           emit topic, message
         end

--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -2,11 +2,11 @@ module Fluent
   class MqttInput < Input
     Plugin.register_input('mqtt', self)
 
-    include Fluent::SetTagKeyMixin
-    config_set_default :include_tag_key, false
-    
-    include Fluent::SetTimeKeyMixin
-    config_set_default :include_time_key, true
+    #include Fluent::SetTagKeyMixin
+    #config_set_default :include_tag_key, false
+    #
+    #include Fluent::SetTimeKeyMixin
+    #config_set_default :include_time_key, true
     
     config_param :port, :integer, :default => 1883
     config_param :bind, :string, :default => '127.0.0.1'
@@ -44,10 +44,10 @@ module Fluent
       if message.class == Array
         message.each do |data|
           $log.debug "#{topic}: #{data}"
-          Fluent::Engine.emit(topic , time , data)
+          router.emit(topic , time , data)
         end
       else
-        Fluent::Engine.emit(topic , time , message)
+        router.emit(topic , time , message)
       end
     end
 
@@ -60,6 +60,7 @@ module Fluent
         $log.warn_backtrace $!.backtrace         
       end
     end
+
     def shutdown
       @thread.kill
       @connect.disconnect

--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -1,0 +1,100 @@
+module Fluent
+  class MqttOutput < BufferedOutput
+    # First, register the plugin. NAME is the name of this plugin
+    # and identifies the plugin in the configuration file.
+    Fluent::Plugin.register_output('mqtt', self)
+
+    # config_param defines a parameter. You can refer a parameter via @path instance variable
+    # Without :default, a parameter is required.
+    config_param :port, :integer, :default => 1883
+    config_param :bind, :string, :default => '127.0.0.1'
+    #config_param :topic, :string, :default => '#'
+    config_param :username, :string, :default => nil
+    config_param :password, :string, :default => nil
+    config_param :topic_rewrite_pattern, :string, :default => '^([\w\/]+)$'
+    config_param :topic_rewrite_replacement, :string, :default => '\1/rewritten'
+
+
+    # This method is called before starting.
+    # 'conf' is a Hash that includes configuration parameters.
+    # If the configuration is invalid, raise Fluent::ConfigError.
+    def configure(conf)
+      super
+
+      # You can also refer raw parameter via conf[name].
+      @bind ||= conf['bind']
+      #@topic ||= conf['topic']
+      @port ||= conf['port']
+      @username ||= conf['username']
+      @password ||= conf['password']
+      @topic_rewrite_pattern ||= conf['topic_rewrite_pattern']
+      @topic_rewrite_replacement ||= conf['topic_rewrite_replacement']
+    end
+
+    # This method is called when starting.
+    # Open sockets or files here.
+    def start
+      super
+
+      $log.debug "start mqtt host: #{@bind}, port: #{@port}, username: #{@username}, password: #{@password}"
+      @connect = MQTT::Client.connect(host: @bind, port: @port,
+                                      username: @username, password: @password)
+#      @connect.subscribe(@topic)
+#
+#      @thread = Thread.new do
+#        @connect.get do |topic,message|
+#          topic.gsub!("/","\.")
+#          $log.debug "#{topic}: #{message}"
+#          emit topic, json_parse(message)
+#        end
+#      end
+    end
+
+    # This method is called when shutting down.
+    # Shutdown the thread and close sockets or files here.
+    def shutdown
+      super
+
+      @connect.disconnect
+    end
+
+    # This method is called when an event reaches to Fluentd.
+    # Convert the event to a raw string.
+    def format(tag, time, record)
+      [tag, time, record].to_json + "\n"
+      ## Alternatively, use msgpack to serialize the object.
+      # [tag, time, record].to_msgpack
+    end
+
+    # This method is called every flush interval. Write the buffer chunk
+    # to files or databases here.
+    # 'chunk' is a buffer chunk that includes multiple formatted
+    # events. You can use 'data = chunk.read' to get all events and
+    # 'chunk.open {|io| ... }' to get IO objects.
+    #
+    # NOTE! This method is called by internal thread, not Fluentd's main thread. So IO wait doesn't affect other plugins.
+    def write(chunk)
+      data = chunk.read
+      #print data
+      json = json_parse(data)
+      #print json[0]
+      @connect.publish(json[0].gsub(Regexp.new(@topic_rewrite_pattern), @topic_rewrite_replacement), json[2].to_json)
+    end
+
+    ## Optionally, you can use chunk.msgpack_each to deserialize objects.
+    #def write(chunk)
+    #  chunk.msgpack_each {|(tag,time,record)|
+    #  }
+    #end
+    
+    def json_parse message
+      begin
+        y = Yajl::Parser.new
+        y.parse(message)
+      rescue
+        $log.error "JSON parse error", :error => $!.to_s, :error_class => $!.class.to_s
+        $log.warn_backtrace $!.backtrace         
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -39,15 +39,6 @@ module Fluent
       $log.debug "start mqtt host: #{@bind}, port: #{@port}, username: #{@username}, password: #{@password}"
       @connect = MQTT::Client.connect(host: @bind, port: @port,
                                       username: @username, password: @password)
-#      @connect.subscribe(@topic)
-#
-#      @thread = Thread.new do
-#        @connect.get do |topic,message|
-#          topic.gsub!("/","\.")
-#          $log.debug "#{topic}: #{message}"
-#          emit topic, json_parse(message)
-#        end
-#      end
     end
 
     # This method is called when shutting down.

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -20,7 +20,7 @@ class MqttInputTest < Test::Unit::TestCase
   end
 
 
- CONFIG = %[
+  CONFIG = %[
   ]
 
   def create_driver(conf = CONFIG) 
@@ -38,7 +38,7 @@ class MqttInputTest < Test::Unit::TestCase
 
 
   def sub_client
-    connect = MQTT::Client.connect
+    connect = MQTT::Client.connect(host: '127.0.0.1', port: 1883)
     connect.subscribe('#')
     return connect
   end


### PR DESCRIPTION
Dear yuuna,

I added output plugin and modify input plugin to support parser plugin (format option). Test codes are not implemented yet. Are you interested in merging it? The purposes of adding output plugin are to support data conversion by using Parser like fluent-plugin-xml-parser and uploading log files via MQTT.

https://github.com/toyokazu/fluent-plugin-xml-parser

Since many functions are added in this version, if you don't like to merge it, I'd like to publish new gem as the other name, for example, fluent-plugin-mqtt-io.

I'd like to have your feedback.
## Best Regards,

Toyokazu Akiyama
