### PR TITLE
in_mqtt: Migrate to use v0.14 API

### DIFF
--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -8,19 +8,25 @@ module Fluent::Plugin
 
     helpers :thread, :inject, :compat_parameters, :parser
 
+    DEFAULT_PARSER_TYPE = 'none'
+
     config_set_default :include_tag_key, false
     config_set_default :include_time_key, true
 
     config_param :port, :integer, :default => 1883
     config_param :bind, :string, :default => '127.0.0.1'
     config_param :topic, :string, :default => '#'
-    config_param :format, :string, :default => 'none'
+    config_param :format, :string, :default => DEFAULT_PARSER_TYPE
     config_param :username, :string, :default => nil
     config_param :password, :string, :default => nil
     config_param :ssl, :bool, :default => nil
     config_param :ca, :string, :default => nil
     config_param :key, :string, :default => nil
     config_param :cert, :string, :default => nil
+
+    config_section :parse do
+      config_set_default :@type, DEFAULT_PARSER_TYPE
+    end
 
     def configure(conf)
       compat_parameters_convert(conf, :inject, :parser)

--- a/lib/fluent/plugin/in_mqtt.rb
+++ b/lib/fluent/plugin/in_mqtt.rb
@@ -25,10 +25,6 @@ module Fluent::Plugin
 
     def configure(conf)
       super
-      @bind ||= conf['bind']
-      @topic ||= conf['topic']
-      @port ||= conf['port']
-
       configure_parser(conf)
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/helpers'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -1,6 +1,7 @@
 require 'helper'
+require 'fluent/test/driver/input'
 
-class Fluent::MqttInput
+class Fluent::Plugin::MqttInput
   #def emit topic, message , time = Fluent::Engine.now
     #if message.class == Array
       #message.each do |data|
@@ -14,6 +15,8 @@ class Fluent::MqttInput
 
 end
 
+include Fluent::Test::Helpers
+
 class MqttInputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
@@ -24,7 +27,7 @@ class MqttInputTest < Test::Unit::TestCase
              format json ]
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::MqttInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::MqttInput).configure(conf)
   end
 
   def test_configure_1
@@ -72,21 +75,20 @@ class MqttInputTest < Test::Unit::TestCase
          port 1883
          format json ]
     )
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    time = event_time("2011-01-02 13:14:15 UTC")
     data = [
       {tag: "tag1", message: {"t" => time, "v" => {"a"=>1}}},
       {tag: "tag2", message: {"t" => time, "v" => {"a"=>1}}},
       {tag: "tag3", message: {"t" => time, "v" => {"a"=>32}}},
     ]
 
-    d.run do
+    d.run(expect_emits: 3, timeout: 5) do
       data.each do |record|
         send_data record[:tag], record[:message], d.instance.format
-        sleep 0.1
       end
     end
 
-    emits = d.emits
+    emits = d.events
     assert_equal('tag1', emits[0][0])
     assert_equal({"t" => time, "v" => {"a"=>1}}, emits[0][2])
 
@@ -104,7 +106,7 @@ class MqttInputTest < Test::Unit::TestCase
          format json
          time_key t ]
     )
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    time = event_time("2011-01-02 13:14:15 UTC")
     data = [
       {tag: "tag1", message: {"t" => time, "v" => {"a"=>1}}},
       {tag: "tag2", message: {"t" => time, "v" => {"a"=>1}}},
@@ -112,13 +114,13 @@ class MqttInputTest < Test::Unit::TestCase
       {tag: "tag3", message: {"t" => time, "v" => {"a"=>32}}},
     ]
 
-    d.run do
+    d.run(expect_emits: 4, timeout: 5) do
       data.each do |record|
         send_data record[:tag], record[:message], d.instance.format
       end
     end
 
-    emits = d.emits
+    emits = d.events
     assert_equal('tag1', emits[0][0])
     assert_equal(time, emits[0][1])
     assert_equal({"v" => {"a"=>1}}, emits[0][2])
@@ -137,13 +139,13 @@ class MqttInputTest < Test::Unit::TestCase
       {tag: "tag3", message: ''},
     ]
 
-    d.run do
+    d.run(expect_emits: 3, timeout: 5) do
       data.each do |record|
         send_data record[:tag], record[:message], d.instance.format
       end
     end
 
-    emits = d.emits
+    emits = d.events
     time = Fluent::Engine.now
     assert_equal('tag1', emits[0][0])
     assert_equal({'message' => 'hello world'}, emits[0][2])
@@ -161,20 +163,20 @@ class MqttInputTest < Test::Unit::TestCase
          keys time,message]
     )
 
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    time = event_time("2011-01-02 13:14:15 UTC")
     data = [
       {tag: "tag1", message: "#{time},hello world" },
       {tag: "tag2", message: "#{time},hello to you to" },
       {tag: "tag3", message: "#{time}," },
     ]
 
-    d.run do
+    d.run(expect_emits: 3, timeout: 5) do
       data.each do |record|
         send_data record[:tag], record[:message], d.instance.format
       end
     end
 
-    emits = d.emits
+    emits = d.events
     #puts 'emits length', emits.length.to_s
     assert_equal('tag1', emits[0][0])
     assert_equal({'time' => time.to_s, 'message' => 'hello world'}, emits[0][2])
@@ -195,7 +197,7 @@ class MqttInputTest < Test::Unit::TestCase
          time_format %S]
     )
 
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    time = event_time("2011-01-02 13:14:15 UTC")
     data = [
       {tag: "tag1", message: "#{time},abc" },
       {tag: "tag2", message: "#{time},def" },
@@ -203,13 +205,13 @@ class MqttInputTest < Test::Unit::TestCase
       {tag: "tag3", message: "#{time}," },
     ]
 
-    d.run do
+    d.run(expect_emits: 4, timeout: 5) do
       data.each do |record|
         send_data record[:tag], record[:message], d.instance.format
       end
     end
 
-    emits = d.emits
+    emits = d.events
     assert_equal('tag1', emits[0][0])
     assert_equal({'message' => 'abc'}, emits[0][2])
 
@@ -234,6 +236,5 @@ class MqttInputTest < Test::Unit::TestCase
       else
         sub_client.publish(tag, record)
     end
-    sleep 0.2
   end
 end

--- a/test/plugin/test_in_mqtt.rb
+++ b/test/plugin/test_in_mqtt.rb
@@ -48,7 +48,7 @@ class MqttInputTest < Test::Unit::TestCase
          time_key time]
     )
     assert_equal 'csv', d2.instance.format
-    assert_equal 'time', d2.instance.time_key
+    assert_equal 'time', d2.instance.inject_config.time_key
   end
 
   def test_configure_2
@@ -123,7 +123,7 @@ class MqttInputTest < Test::Unit::TestCase
     emits = d.events
     assert_equal('tag1', emits[0][0])
     assert_equal(time, emits[0][1])
-    assert_equal({"v" => {"a"=>1}}, emits[0][2])
+    assert_equal({"v" => {"a"=>1}, "t" => time}, emits[0][2])
   end
 
   def test_format_none
@@ -194,10 +194,10 @@ class MqttInputTest < Test::Unit::TestCase
          format csv
          keys time2,message
          time_key time2
-         time_format %S]
+         time_format %s]
     )
 
-    time = event_time("2011-01-02 13:14:15 UTC")
+    time = event_time("2011-01-02 13:14:15 UTC").to_i # to obtain unixtime stamp
     data = [
       {tag: "tag1", message: "#{time},abc" },
       {tag: "tag2", message: "#{time},def" },
@@ -213,16 +213,16 @@ class MqttInputTest < Test::Unit::TestCase
 
     emits = d.events
     assert_equal('tag1', emits[0][0])
-    assert_equal({'message' => 'abc'}, emits[0][2])
+    assert_equal({'message' => 'abc', "time2" => time}, emits[0][2])
 
     assert_equal('tag2', emits[1][0])
-    assert_equal({'message' => 'def'}, emits[1][2])
+    assert_equal({'message' => 'def', "time2" => time}, emits[1][2])
 
     assert_equal('tag3', emits[2][0])
-    assert_equal({'message' => 'ghi'}, emits[2][2])
+    assert_equal({'message' => 'ghi', "time2" => time}, emits[2][2])
 
     assert_equal('tag3', emits[3][0])
-    assert_equal({'message' => nil}, emits[3][2])
+    assert_equal({'message' => nil, "time2"=> time}, emits[3][2])
   end
 
   def send_data tag, record, format


### PR DESCRIPTION
This PR patches should be treated as major update.
Fluentd core development team strongly recommended to use v0.14 API, and I've tried to use v0.14 API in this plugin.

Thanks,