### PR TITLE
out_mqtt: Add elementary testcases and adopt v0.14 compat layer

### DIFF
--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -44,11 +44,13 @@ module Fluent
       @port ||= conf['port']
       @formatter = Plugin.new_formatter(@format)
       @formatter.configure(conf)
+      if conf.has_key?('buffer_chunk_limit')
+        #check buffer_size
+        conf['buffer_chunk_limit'] = available_buffer_chunk_limit(conf)
+      end
     end
 
     def start
-      #check buffer_size
-      @buffer.buffer_chunk_limit = available_buffer_chunk_limit
 
       $log.debug "start mqtt #{@bind}"
       opts = {host: @bind,
@@ -84,12 +86,12 @@ module Fluent
     # Following limits are heuristic. BSON is sometimes bigger than MessagePack and JSON.
     LIMIT_MQTT = 2 * 1024  # 2048kb
 
-    def available_buffer_chunk_limit
-      if @buffer.buffer_chunk_limit > LIMIT_MQTT
-        log.warn ":buffer_chunk_limit(#{@buffer.buffer_chunk_limit}) is large. Reset :buffer_chunk_limit with #{LIMIT_MQTT}"
+    def available_buffer_chunk_limit(conf)
+      if conf['buffer_chunk_limit'] > LIMIT_MQTT
+        log.warn ":buffer_chunk_limit(#{conf['buffer_chunk_limit']}) is large. Reset :buffer_chunk_limit with #{LIMIT_MQTT}"
         LIMIT_MQTT
       else
-        @buffer.buffer_chunk_limit
+        conf['buffer_chunk_limit']
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -24,6 +24,7 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/in_mqtt'
+require 'fluent/plugin/out_mqtt'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_out_mqtt.rb
+++ b/test/plugin/test_out_mqtt.rb
@@ -1,0 +1,71 @@
+require_relative '../helper'
+
+class MqttOutputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[ bind 127.0.0.1
+              port 1883
+              format json ]
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::BufferedOutputTestDriver.new(Fluent::OutMqtt).configure(conf)
+  end
+
+  def sub_client(topic = "td-agent/#")
+    connect = MQTT::Client.connect("localhost")
+    connect.subscribe(topic)
+    return connect
+  end
+
+  def test_configure_1
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format json]
+    )
+    assert_equal '127.0.0.1', d.instance.bind
+    assert_equal 1883, d.instance.port
+    assert_equal 'json', d.instance.instance_variable_get(:@format)
+
+    d2 = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format csv
+         fields time,message
+         time_key time]
+    )
+    assert_equal 'csv', d2.instance.instance_variable_get(:@format)
+    assert_equal 'time', d2.instance.inject_config.time_key
+  end
+
+  def test_format_csv
+    d = create_driver(
+      %[ bind 127.0.0.1
+         port 1883
+         format csv
+         fields time,message]
+    )
+
+    client = sub_client
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    data = [
+      {tag: "tag1", message: "#{time},hello world" },
+      {tag: "tag2", message: "#{time},hello to you to" },
+      {tag: "tag3", message: "#{time}," },
+    ]
+
+    d.run do
+      data.each do |record|
+        d.emit(record, time)
+      end
+    end
+    3.times do |i|
+      record = client.get
+      assert_equal "td-agent", record[0]
+      assert_equal "\"2011-01-02T13:14:15Z\",\"#{data[i][:message]}\"\n", record[1]
+    end
+
+  end
+end


### PR DESCRIPTION
Current implementation cannot work with v0.14 Compat layer as follows:

```log
NoMethodError: undefined method `buffer_chunk_limit' for #<Fluent::Plugin::MemoryBuffer:007fc32c3885c8>
```

And I've tried to add test cases to out_mqtt.

Could you review this change?