### PR TITLE
Migrate v0.14 api out_mqtt

### DIFF
--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -64,7 +64,7 @@ module Fluent::Plugin
 
     def start
 
-      $log.debug "start mqtt #{@bind}"
+      log.debug "start mqtt #{@bind}"
       opts = {host: @bind,
               port: @port}
       opts[:client_id] = @client_id if @client_id

--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -37,10 +37,6 @@ module Fluent::Plugin
       config_set_default :time_format, "%Y-%m-%dT%H:%M:%S%z"
     end
 
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
     def initialize
       super
 

--- a/lib/fluent/plugin/out_mqtt.rb
+++ b/lib/fluent/plugin/out_mqtt.rb
@@ -6,7 +6,7 @@ module Fluent::Plugin
   class OutMqtt < Output
     Fluent::Plugin.register_output('mqtt', self)
 
-    helpers :compat_parameters, :inject
+    helpers :compat_parameters, :inject, :formatter
 
     DEFAULT_BUFFER_TYPE = "memory"
 
@@ -37,7 +37,6 @@ module Fluent::Plugin
       config_set_default :time_format, "%Y-%m-%dT%H:%M:%S%z"
     end
 
-
     unless method_defined?(:log)
       define_method(:log) { $log }
     end
@@ -51,13 +50,12 @@ module Fluent::Plugin
     end
 
     def configure(conf)
-      compat_parameters_convert(conf, :buffer, :inject)
+      compat_parameters_convert(conf, :buffer, :inject, :formatter)
       super
       @bind ||= conf['bind']
       @topic ||= conf['topic']
       @port ||= conf['port']
-      @formatter = Fluent::Plugin.new_formatter(@format)
-      @formatter.configure(conf)
+      @formatter = formatter_create
       if conf.has_key?('buffer_chunk_limit')
         #check buffer_size
         conf['buffer_chunk_limit'] = available_buffer_chunk_limit(conf)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,3 +28,5 @@ require 'fluent/plugin/out_mqtt'
 
 class Test::Unit::TestCase
 end
+
+include Fluent::Test::Helpers

--- a/test/plugin/test_out_mqtt.rb
+++ b/test/plugin/test_out_mqtt.rb
@@ -80,5 +80,39 @@ class MqttOutputTest < Test::Unit::TestCase
         assert_equal "\"2011-01-02T22:14:15+0900\",\"#{data[i][:message]}\"\n", record[1]
       end
     end
+
+    def test_format_json
+      ENV['TZ'] = 'Asia/Tokyo'
+
+      d = create_driver(
+        %[ bind 127.0.0.1
+           port 1883
+           format json
+           time_type string
+           time_format %Y-%m-%dT%H:%M:%S%z
+           fields time,message]
+      )
+
+      client = sub_client
+      time = event_time("2011-01-02 13:14:15 UTC")
+      data = [
+        {tag: "tag1", message: "#{time},hello world" },
+        {tag: "tag2", message: "#{time},hello to you to" },
+        {tag: "tag3", message: "#{time}," },
+      ]
+
+      d.run(default_tag: "test") do
+        data.each do |record|
+          d.feed(time, record)
+        end
+      end
+      3.times do |i|
+        record = client.get
+        assert_equal "td-agent", record[0]
+        assert_equal "{\"tag\":\"#{data[i][:tag]}\",\
+\"message\":\"#{data[i][:message]}\",\
+\"time\":\"2011-01-02T22:14:15+0900\"}\n", record[1]
+      end
+    end
   end
 end


### PR DESCRIPTION
As a previous [comment](https://github.com/yuuna/fluent-plugin-mqtt/pull/10#issuecomment-296905940), I've tried to use v0.14 API in `out_mqtt`.